### PR TITLE
Generalize svg style mechanism

### DIFF
--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -78,7 +78,7 @@ def _maybe_unpack(result):
         return result
 
 
-def apply_svg_defaults(supplied, **defaults):
+def apply_svg_defaults(supplied, defaults):
     """Return a dictionary of SVG style attributes with defaults filled in.
     Args:
        supplied:   a dictionary of SVG style attributes, typically given as

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -91,15 +91,13 @@ def apply_svg_defaults(supplied, defaults):
 
 SVG_ATTRIBUTE_NAMES = {
     'fill_color': 'fill',
-    'fill_rule': 'fill-rule',
     'stroke_color': 'stroke',
-    'stroke_width': 'stroke-width',
 }
 
 
 def svg_style(style_elements):
     """Return the style text for a dictionary of style elements."""
-    return " ".join('%s="%s"' % (SVG_ATTRIBUTE_NAMES.get(k, k), v)
+    return " ".join('%s="%s"' % (SVG_ATTRIBUTE_NAMES.get(k, k).replace("_", "-"), v)
                     for k, v in style_elements.items())
 
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -78,6 +78,31 @@ def _maybe_unpack(result):
         return result
 
 
+def apply_svg_defaults(supplied, **defaults):
+    """Return a dictionary of SVG style attributes with defaults filled in.
+    Args:
+       supplied:   a dictionary of SVG style attributes, typically given as
+                   **kwargs to a .svg() method
+       other args: if any of these are missing from the supplied args, they
+                   are filled in from here.
+    """
+    return defaults | supplied
+
+
+SVG_ATTRIBUTE_NAMES = {
+    'fill_color': 'fill',
+    'fill_rule': 'fill-rule',
+    'stroke_color': 'stroke',
+    'stroke_width': 'stroke-width',
+}
+
+
+def svg_style(style_elements):
+    """Return the style text for a dictionary of style elements."""
+    return " ".join('%s="%s"' % (SVG_ATTRIBUTE_NAMES.get(k, k), v)
+                    for k, v in style_elements.items())
+
+
 class CAP_STYLE:
     """Buffer cap styles."""
 

--- a/shapely/geometry/base.py
+++ b/shapely/geometry/base.py
@@ -81,10 +81,10 @@ def _maybe_unpack(result):
 def apply_svg_defaults(supplied, defaults):
     """Return a dictionary of SVG style attributes with defaults filled in.
     Args:
-       supplied:   a dictionary of SVG style attributes, typically given as
-                   **kwargs to a .svg() method
-       other args: if any of these are missing from the supplied args, they
-                   are filled in from here.
+       supplied: a dictionary of SVG style attributes, typically given as
+                 **kwargs to a .svg() method
+       defaults: if any of these are missing from the supplied args, they
+                 are filled in from here.
     """
     return defaults | supplied
 

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import shapely
 from shapely.decorators import deprecate_positional
-from shapely.geometry.base import JOIN_STYLE, BaseGeometry
+from shapely.geometry.base import JOIN_STYLE, BaseGeometry, apply_svg_defaults, svg_style
 from shapely.geometry.point import Point
 
 __all__ = ["LineString"]
@@ -83,7 +83,7 @@ class LineString(BaseGeometry):
         """Return a GeoJSON-like mapping of the LineString geometry."""
         return {"type": "LineString", "coordinates": tuple(self.coords)}
 
-    def svg(self, scale_factor=1.0, stroke_color=None, opacity=None):
+    def svg(self, scale_factor=1.0, **style_args):
         """Return SVG polyline element for the LineString geometry.
 
         Parameters
@@ -95,19 +95,19 @@ class LineString(BaseGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.8
+        Other SVG style parameters also may be given.
 
         """
         if self.is_empty:
             return "<g />"
-        if stroke_color is None:
-            stroke_color = "#66cc99" if self.is_valid else "#ff3333"
-        if opacity is None:
-            opacity = 0.8
         pnt_format = " ".join(["{},{}".format(*c) for c in self.coords])
+        style = svg_style(apply_svg_defaults(style_args,
+                                             opacity=0.8,
+                                             fill="none",
+                                             stroke_color="#66cc99" if self.is_valid else "#ff3333",
+                                             stroke_width=2.0 * scale_factor))
         return (
-            f'<polyline fill="none" stroke="{stroke_color}" '
-            f'stroke-width="{2.0 * scale_factor}" '
-            f'points="{pnt_format}" opacity="{opacity}" />'
+            f'<polyline {style} points="{pnt_format}" />'
         )
 
     @property

--- a/shapely/geometry/linestring.py
+++ b/shapely/geometry/linestring.py
@@ -102,10 +102,10 @@ class LineString(BaseGeometry):
             return "<g />"
         pnt_format = " ".join(["{},{}".format(*c) for c in self.coords])
         style = svg_style(apply_svg_defaults(style_args,
-                                             opacity=0.8,
-                                             fill="none",
-                                             stroke_color="#66cc99" if self.is_valid else "#ff3333",
-                                             stroke_width=2.0 * scale_factor))
+                                             dict(opacity=0.8,
+                                                  fill="none",
+                                                  stroke_color="#66cc99" if self.is_valid else "#ff3333",
+                                                  stroke_width=2.0 * scale_factor)))
         return (
             f'<polyline {style} points="{pnt_format}" />'
         )

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -3,7 +3,7 @@
 import shapely
 from shapely.errors import EmptyPartError
 from shapely.geometry import linestring
-from shapely.geometry.base import BaseMultipartGeometry
+from shapely.geometry.base import BaseMultipartGeometry, apply_svg_defaults
 
 __all__ = ["MultiLineString"]
 
@@ -67,7 +67,7 @@ class MultiLineString(BaseMultipartGeometry):
             "coordinates": tuple(tuple(c for c in g.coords) for g in self.geoms),
         }
 
-    def svg(self, scale_factor=1.0, stroke_color=None, opacity=None):
+    def svg(self, scale_factor=1.0, **style_args):
         """Return a group of SVG polyline elements for the LineString geometry.
 
         Parameters
@@ -79,15 +79,17 @@ class MultiLineString(BaseMultipartGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.8
+        Other SVG style parameters may also be given.
 
         """
         if self.is_empty:
             return "<g />"
-        if stroke_color is None:
-            stroke_color = "#66cc99" if self.is_valid else "#ff3333"
+        style = apply_svg_defaults(style_args,
+                                   stroke_color=("#66cc99" if self.is_valid else "#ff3333"))
         return (
             "<g>"
-            + "".join(p.svg(scale_factor, stroke_color, opacity) for p in self.geoms)
+            + "".join(p.svg(scale_factor=scale_factor,
+                            **style) for p in self.geoms)
             + "</g>"
         )
 

--- a/shapely/geometry/multilinestring.py
+++ b/shapely/geometry/multilinestring.py
@@ -85,7 +85,7 @@ class MultiLineString(BaseMultipartGeometry):
         if self.is_empty:
             return "<g />"
         style = apply_svg_defaults(style_args,
-                                   stroke_color=("#66cc99" if self.is_valid else "#ff3333"))
+                                   dict(stroke_color=("#66cc99" if self.is_valid else "#ff3333")))
         return (
             "<g>"
             + "".join(p.svg(scale_factor=scale_factor,

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -5,7 +5,7 @@ import numpy as np
 import shapely
 from shapely.errors import EmptyPartError
 from shapely.geometry import point
-from shapely.geometry.base import BaseMultipartGeometry
+from shapely.geometry.base import BaseMultipartGeometry, apply_svg_defaults
 
 __all__ = ["MultiPoint"]
 
@@ -76,7 +76,7 @@ class MultiPoint(BaseMultipartGeometry):
             "coordinates": tuple(g.coords[0] for g in self.geoms),
         }
 
-    def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
+    def svg(self, scale_factor=1.0, **style_args):
         """Return a group of SVG circle elements for the MultiPoint geometry.
 
         Parameters
@@ -88,15 +88,16 @@ class MultiPoint(BaseMultipartGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+        Other SVG style parameters may also be given.
 
         """
         if self.is_empty:
             return "<g />"
-        if fill_color is None:
-            fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        style = apply_svg_defaults(style_args,
+                                   fill_color="#66cc99" if self.is_valid else "#ff3333")
         return (
             "<g>"
-            + "".join(p.svg(scale_factor, fill_color, opacity) for p in self.geoms)
+            + "".join(p.svg(scale_factor=scale_factor, **style) for p in self.geoms)
             + "</g>"
         )
 

--- a/shapely/geometry/multipoint.py
+++ b/shapely/geometry/multipoint.py
@@ -94,7 +94,7 @@ class MultiPoint(BaseMultipartGeometry):
         if self.is_empty:
             return "<g />"
         style = apply_svg_defaults(style_args,
-                                   fill_color="#66cc99" if self.is_valid else "#ff3333")
+                                   dict(fill_color="#66cc99" if self.is_valid else "#ff3333"))
         return (
             "<g>"
             + "".join(p.svg(scale_factor=scale_factor, **style) for p in self.geoms)

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -115,7 +115,7 @@ class MultiPolygon(BaseMultipartGeometry):
         if self.is_empty:
             return "<g />"
         style = apply_svg_defaults(style_args,
-                                   fill_color="#66cc99" if self.is_valid else "#ff3333")
+                                   dict(fill_color="#66cc99" if self.is_valid else "#ff3333"))
         return (
             "<g>"
             + "".join(p.svg(scale_factor=scale_factor, **style) for p in self.geoms)

--- a/shapely/geometry/multipolygon.py
+++ b/shapely/geometry/multipolygon.py
@@ -2,7 +2,7 @@
 
 import shapely
 from shapely.geometry import polygon
-from shapely.geometry.base import BaseMultipartGeometry
+from shapely.geometry.base import BaseMultipartGeometry, apply_svg_defaults
 
 __all__ = ["MultiPolygon"]
 
@@ -97,7 +97,7 @@ class MultiPolygon(BaseMultipartGeometry):
             allcoords.append(tuple(coords))
         return {"type": "MultiPolygon", "coordinates": allcoords}
 
-    def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
+    def svg(self, scale_factor=1.0, **style_args):
         """Return group of SVG path elements for the MultiPolygon geometry.
 
         Parameters
@@ -109,15 +109,16 @@ class MultiPolygon(BaseMultipartGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+        Other SVG style parameters may also be given.
 
         """
         if self.is_empty:
             return "<g />"
-        if fill_color is None:
-            fill_color = "#66cc99" if self.is_valid else "#ff3333"
+        style = apply_svg_defaults(style_args,
+                                   fill_color="#66cc99" if self.is_valid else "#ff3333")
         return (
             "<g>"
-            + "".join(p.svg(scale_factor, fill_color, opacity) for p in self.geoms)
+            + "".join(p.svg(scale_factor=scale_factor, **style) for p in self.geoms)
             + "</g>"
         )
 

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -138,10 +138,10 @@ class Point(BaseGeometry):
         if self.is_empty:
             return "<g />"
         style = svg_style(apply_svg_defaults(style_args,
-                                             opacity=0.6,
-                                             fill_color="#66cc99" if self.is_valid else "#ff3333",
-                                             stroke="#555555",
-                                             stroke-width=scale_factor))
+                                             dict(opacity=0.6,
+                                                  fill_color="#66cc99" if self.is_valid else "#ff3333",
+                                                  stroke="#555555",
+                                                  stroke_width=scale_factor)))
         return (
             f'<circle cx="{self.x}" cy="{self.y}" r="{3.0 * scale_factor}" {style} />'
         )

--- a/shapely/geometry/point.py
+++ b/shapely/geometry/point.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import shapely
 from shapely.errors import DimensionError
-from shapely.geometry.base import BaseGeometry
+from shapely.geometry.base import BaseGeometry, apply_svg_defaults, svg_style
 
 __all__ = ["Point"]
 
@@ -120,7 +120,7 @@ class Point(BaseGeometry):
         coords = self.coords
         return {"type": "Point", "coordinates": coords[0] if len(coords) > 0 else ()}
 
-    def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
+    def svg(self, **style_args):
         """Return SVG circle element for the Point geometry.
 
         Parameters
@@ -132,18 +132,18 @@ class Point(BaseGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+        Other SVG style parameters may also be given.
 
         """
         if self.is_empty:
             return "<g />"
-        if fill_color is None:
-            fill_color = "#66cc99" if self.is_valid else "#ff3333"
-        if opacity is None:
-            opacity = 0.6
+        style = svg_style(apply_svg_defaults(style_args,
+                                             opacity=0.6,
+                                             fill_color="#66cc99" if self.is_valid else "#ff3333",
+                                             stroke="#555555",
+                                             stroke-width=scale_factor))
         return (
-            f'<circle cx="{self.x}" cy="{self.y}" r="{3.0 * scale_factor}" '
-            f'stroke="#555555" stroke-width="{1.0 * scale_factor}" fill="{fill_color}" '
-            f'opacity="{opacity}" />'
+            f'<circle cx="{self.x}" cy="{self.y}" r="{3.0 * scale_factor}" {style} />'
         )
 
     @property

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -6,7 +6,7 @@ import shapely
 from shapely import _geometry_helpers
 from shapely.algorithms.cga import signed_area  # noqa
 from shapely.errors import TopologicalError
-from shapely.geometry.base import BaseGeometry
+from shapely.geometry.base import BaseGeometry, apply_svg_defaults, svg_style
 from shapely.geometry.linestring import LineString
 from shapely.geometry.point import Point
 
@@ -278,7 +278,7 @@ class Polygon(BaseGeometry):
                 coords.append(tuple(hole.coords))
         return {"type": "Polygon", "coordinates": tuple(coords)}
 
-    def svg(self, scale_factor=1.0, fill_color=None, opacity=None):
+    def svg(self, scale_factor=1.0, **style_args):
         """Return SVG path element for the Polygon geometry.
 
         Parameters
@@ -290,14 +290,11 @@ class Polygon(BaseGeometry):
             geometry is valid, and "#ff3333" if invalid.
         opacity : float
             Float number between 0 and 1 for color opacity. Default value is 0.6
+        Other SVG style parameters may also be given.
 
         """
         if self.is_empty:
             return "<g />"
-        if fill_color is None:
-            fill_color = "#66cc99" if self.is_valid else "#ff3333"
-        if opacity is None:
-            opacity = 0.6
         exterior_coords = [["{},{}".format(*c) for c in self.exterior.coords]]
         interior_coords = [
             ["{},{}".format(*c) for c in interior.coords] for interior in self.interiors
@@ -308,9 +305,14 @@ class Polygon(BaseGeometry):
                 for coords in exterior_coords + interior_coords
             ]
         )
+        style = svg_style(apply_svg_defaults(**style_args,
+                                             fill_color="#66cc99" if self.is_valid else "#ff3333",
+                                             fill-rule="evenodd",
+                                             stroke_color="#555555",
+                                             stroke-width=2.0 * scale_factor,
+                                             opacity=0.6)
         return (
-            f'<path fill-rule="evenodd" fill="{fill_color}" stroke="#555555" '
-            f'stroke-width="{2.0 * scale_factor}" opacity="{opacity}" d="{path}" />'
+            f'<path {style} d="{path}" />'
         )
 
     @classmethod

--- a/shapely/geometry/polygon.py
+++ b/shapely/geometry/polygon.py
@@ -305,12 +305,12 @@ class Polygon(BaseGeometry):
                 for coords in exterior_coords + interior_coords
             ]
         )
-        style = svg_style(apply_svg_defaults(**style_args,
-                                             fill_color="#66cc99" if self.is_valid else "#ff3333",
-                                             fill-rule="evenodd",
-                                             stroke_color="#555555",
-                                             stroke-width=2.0 * scale_factor,
-                                             opacity=0.6)
+        style = svg_style(apply_svg_defaults(style_args,
+                                             dict(fill_color="#66cc99" if self.is_valid else "#ff3333",
+                                                  fill_rule="evenodd",
+                                                  stroke_color="#555555",
+                                                  stroke_width=2.0 * scale_factor,
+                                                  opacity=0.6)))
         return (
             f'<path {style} d="{path}" />'
         )


### PR DESCRIPTION
This should help me visualise the PDR rules logic more readily.

The SVG styling provided by shapely wasn't enough to let me produce clear enough diagrams.